### PR TITLE
Add support for overlay networks 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
     <jenkins.version>1.565.3</jenkins.version>
     <jenkins-test-harness.version>1.565.3</jenkins-test-harness.version>
     <findbugs.failOnError>false</findbugs.failOnError>
-    <mesos.version>0.27.0</mesos.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <mesos.version>1.0.0</mesos.version>
+    <protobuf.version>2.6.1</protobuf.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.2</powermock.version>
     <assertj.version>2.1.0</assertj.version>

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -47,12 +47,12 @@ import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-
 import org.apache.commons.collections4.OrderedMapIterator;
 import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.NetworkInfo;
 import org.apache.mesos.Protos.Attribute;
 import org.apache.mesos.Protos.CommandInfo;
 import org.apache.mesos.Protos.ContainerInfo;
@@ -749,6 +749,21 @@ public class JenkinsScheduler implements Scheduler {
             volumeBuilder.setHostPath(volume.getHostPath());
           }
           containerInfoBuilder.addVolumes(volumeBuilder.build());
+        }
+      }
+
+      if (containerInfo.hasNetworkInfos()) {
+        for (MesosSlaveInfo.NetworkInfo networkInfo : containerInfo.getNetworkInfos()) {
+
+          NetworkInfo.Builder networkInfoBuilder = NetworkInfo.newBuilder();
+
+          if (networkInfo.hasNetworkName()) {
+            //Add the virtual network specified, trimming edges for whitespace
+            networkInfoBuilder.setName(networkInfo.getNetworkName().trim());
+            LOGGER.info("Launching container on network " + networkInfo.getNetworkName() );
+          }
+
+          containerInfoBuilder.addNetworkInfos(networkInfoBuilder.build());
         }
       }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -28,6 +28,8 @@ import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.NetworkInfo.Protocol;
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -489,6 +491,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     private final String networking;
     private static final String DEFAULT_NETWORKING = Network.BRIDGE.name();
     private final List<PortMapping> portMappings;
+    private final List<NetworkInfo> networkInfos;
     private final boolean useCustomDockerCommandShell;
     private final String customDockerCommandShell;
     private final boolean dockerPrivilegedMode;
@@ -506,7 +509,8 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
                          List<Volume> volumes,
                          List<Parameter> parameters,
                          String networking,
-                         List<PortMapping> portMappings) throws FormException {
+                         List<PortMapping> portMappings,
+                         List<NetworkInfo> networkInfos) throws FormException {
       this.type = type;
       this.dockerImage = dockerImage;
       this.dockerPrivilegedMode = dockerPrivilegedMode;
@@ -516,6 +520,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       this.customDockerCommandShell = customDockerCommandShell;
       this.volumes = volumes;
       this.parameters = parameters;
+      this.networkInfos = networkInfos;
 
       if (networking == null) {
           this.networking = DEFAULT_NETWORKING;
@@ -542,7 +547,8 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
                 volumes,
                 parameters,
                 networking,
-                portMappings
+                portMappings,
+                networkInfos
         );
     }
 
@@ -560,6 +566,14 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
 
     public List<Parameter> getParameters() {
       return parameters;
+    }
+
+    public List<NetworkInfo> getNetworkInfos() {
+          return networkInfos;
+      }
+
+    public boolean hasNetworkInfos() {
+      return networkInfos != null && !networkInfos.isEmpty();
     }
 
     public String getNetworking() {
@@ -612,6 +626,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) return false;
       if (networking != null ? !networking.equals(that.networking) : that.networking != null) return false;
       if (portMappings != null ? !portMappings.equals(that.portMappings) : that.portMappings != null) return false;
+      if (networkInfos != null ? !networkInfos.equals(that.networkInfos) : that.networkInfos != null) return false;
       if (customDockerCommandShell != null ? !customDockerCommandShell.equals(that.customDockerCommandShell) : that.customDockerCommandShell != null)
         return false;
       if (dockerPrivilegedMode != that.dockerPrivilegedMode) return false;
@@ -626,6 +641,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       result = 31 * result + (volumes != null ? volumes.hashCode() : 0);
       result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
       result = 31 * result + (networking != null ? networking.hashCode() : 0);
+      result = 31 * result + (networkInfos != null ? networkInfos.hashCode() : 0);
       result = 31 * result + (portMappings != null ? portMappings.hashCode() : 0);
       result = 31 * result + (useCustomDockerCommandShell ? 1 : 0);
       result = 31 * result + (customDockerCommandShell != null ? customDockerCommandShell.hashCode() : 0);
@@ -838,4 +854,44 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       return result;
     }
   }
+
+  public static class NetworkInfo extends AbstractDescribableImpl<NetworkInfo> {
+    @Extension
+    public static class DescriptorImpl extends Descriptor<NetworkInfo> {
+        public String getDisplayName() { return ""; }
+    }
+
+    private final String networkName;
+
+    @DataBoundConstructor
+    public NetworkInfo(String networkName) {
+        this.networkName = networkName;
+    }
+
+    public String getNetworkName() {
+        return networkName;
+    }
+
+    public boolean hasNetworkName() {
+      return networkName != null && !networkName.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        NetworkInfo networkInfo = (NetworkInfo) o;
+
+        return networkName != null ? networkName.equals(networkInfo.networkName) : networkInfo.networkName == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = networkName != null ? networkName.hashCode() : 0;
+        return result;
+    }
+}
+
 }

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/ContainerInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/ContainerInfo/config.jelly
@@ -40,6 +40,16 @@
         </f:radioBlock>
     </f:entry>
 
+    <f:entry title="${%Network Info}">
+        <f:repeatableProperty field="networkInfos" add="${%Add Network Info}" minimum="0">
+            <f:entry>
+                <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
+                    <f:repeatableDeleteButton value="${%Delete Network Info}" /><br/>
+                </div>
+            </f:entry>
+        </f:repeatableProperty>
+        </f:entry>
+
     <f:entry title="${%Volumes}">
         <f:repeatableProperty field="volumes" add="${%Add Volume}" minimum="0">
             <f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/NetworkInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/NetworkInfo/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+
+    <f:entry title="${%Name}" field="networkName">
+        <f:textbox clazz="optional"/>
+    </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/NetworkInfo/help-networkName.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/NetworkInfo/help-networkName.html
@@ -1,0 +1,3 @@
+<div>
+    Setting name to a valid network name allows the framework to specify a network for the container to join.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -276,7 +276,8 @@ public class JenkinsSchedulerTest {
                     Collections.<MesosSlaveInfo.Volume>emptyList(),
                     Collections.<MesosSlaveInfo.Parameter>emptyList(),
                     Protos.ContainerInfo.DockerInfo.Network.HOST.name(),
-                    Collections.<MesosSlaveInfo.PortMapping>emptyList());
+                    Collections.<MesosSlaveInfo.PortMapping>emptyList(),
+                    Collections.<MesosSlaveInfo.NetworkInfo>emptyList());
         }
 
         MesosSlaveInfo mesosSlaveInfo = new MesosSlaveInfo(

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosSlaveInfoTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosSlaveInfoTest.java
@@ -70,7 +70,8 @@ public class MesosSlaveInfoTest {
                 new LinkedList<MesosSlaveInfo.Volume>(),
                 new LinkedList<MesosSlaveInfo.Parameter>(),
                 Protos.ContainerInfo.DockerInfo.Network.BRIDGE.name(),
-                null
+                null,
+                new LinkedList<MesosSlaveInfo.NetworkInfo>()
         );
         return new MesosSlaveInfo(
                 label,
@@ -152,5 +153,13 @@ public class MesosSlaveInfoTest {
         assertNull(buildMesosSlaveInfo(null, true).getMesosSlaveInfoForLabel(null).getLabelString());
         assertNull(buildMesosSlaveInfo("label", true).getMesosSlaveInfoForLabel(null));
         assertNull(buildMesosSlaveInfo(null, true).getMesosSlaveInfoForLabel(getLabel("label")));
+    }
+
+    @Test
+    public void getNetworkNameTest() throws IOException, Descriptor.FormException, ANTLRException {
+        MesosSlaveInfo info = buildMesosSlaveInfo("label", false);
+        MesosSlaveInfo.NetworkInfo networkInfo = new MesosSlaveInfo.NetworkInfo("exampleNetwork");
+        info.getContainerInfo().getNetworkInfos().add(networkInfo);
+        assertEquals(info.getContainerInfo().getNetworkInfos().get(0).getNetworkName(), "exampleNetwork");
     }
 }


### PR DESCRIPTION
This patch enables virtual networking through the use of overlay networks. Overlay networks enable you to provide each container in the system with a unique IP address (“IP-per-container”) with isolation guarantees amongst subnets.  This patch adds the capability to specify [NetworkInfo](http://mesos.apache.org/documentation/latest/networking-for-mesos-managed-containers/) name when configuring containerInfo, allowing for a container to be assigned a unique ip address in a specific network.
